### PR TITLE
inject exports from main

### DIFF
--- a/src/it/scala/eu/semberal/dbstress/integration/OrchestratorIntegrationTest.scala
+++ b/src/it/scala/eu/semberal/dbstress/integration/OrchestratorIntegrationTest.scala
@@ -8,6 +8,7 @@ import akka.actor.ActorSystem
 import akka.testkit.{ImplicitSender, TestKit}
 import eu.semberal.dbstress.Orchestrator
 import eu.semberal.dbstress.config.ConfigParser.parseConfigurationYaml
+import eu.semberal.dbstress.util.{CsvResultsExport, JsonResultsExport, ResultsExport}
 import org.scalatest.{BeforeAndAfterAll, Matchers, FlatSpecLike}
 import play.api.libs.json.{JsArray, JsNumber, JsObject, Json}
 import resource.managed
@@ -39,7 +40,8 @@ class OrchestratorIntegrationTest
   "Orchestrator" should "successfully launch the application and check results" in withTempDir { tmpDir =>
     val reader = new InputStreamReader(getClass.getClassLoader.getResourceAsStream("config1.yaml"))
     val config = parseConfigurationYaml(reader, Some("")).right.get
-    new Orchestrator(tmpDir).run(config, system)
+    val exports: List[ResultsExport] = new JsonResultsExport(tmpDir) :: new CsvResultsExport(tmpDir) :: Nil
+    new Orchestrator(exports).run(config, system)
     system.awaitTermination(20.seconds)
 
     /* Test generated JSON */

--- a/src/main/scala/eu/semberal/dbstress/Main.scala
+++ b/src/main/scala/eu/semberal/dbstress/Main.scala
@@ -7,6 +7,7 @@ import akka.actor.ActorSystem
 import com.typesafe.config.ConfigFactory
 import com.typesafe.scalalogging.slf4j.LazyLogging
 import eu.semberal.dbstress.config.ConfigParser.parseConfigurationYaml
+import eu.semberal.dbstress.util.{CsvResultsExport, JsonResultsExport, ResultsExport}
 import scopt.OptionParser
 
 object Main extends LazyLogging {
@@ -77,7 +78,8 @@ object Main extends LazyLogging {
           }
           """)
           val system = ActorSystem("dbstressMaster", dbDispatcherConfig.withFallback(ConfigFactory.load()))
-          new Orchestrator(outputDir).run(sc, system)
+          val exports: List[ResultsExport] = new JsonResultsExport(outputDir) :: new CsvResultsExport(outputDir) :: Nil
+          new Orchestrator(exports).run(sc, system)
         case Left(msg) =>
           System.err.println(s"Configuration error: $msg")
           System.exit(2) // exit status 2 when configuration parsing error has occurred

--- a/src/main/scala/eu/semberal/dbstress/Orchestrator.scala
+++ b/src/main/scala/eu/semberal/dbstress/Orchestrator.scala
@@ -7,12 +7,13 @@ import com.typesafe.scalalogging.slf4j.LazyLogging
 import eu.semberal.dbstress.actor.ManagerActor.RunScenario
 import eu.semberal.dbstress.actor.{ManagerActor, ResultsExporterActor, TerminatorActor}
 import eu.semberal.dbstress.model.Configuration.ScenarioConfig
+import eu.semberal.dbstress.util.{ResultsExport, CsvResultsExport, JsonResultsExport}
 
-class Orchestrator(outputDir: File) extends LazyLogging {
+class Orchestrator(exports: List[ResultsExport]) extends LazyLogging {
 
   def run(sc: ScenarioConfig, actorSystem: ActorSystem): Unit = {
     val terminator = actorSystem.actorOf(Props[TerminatorActor], "terminator")
-    val resultsExporter = actorSystem.actorOf(ResultsExporterActor.defaultProps(outputDir), "resultsExporter")
+    val resultsExporter = actorSystem.actorOf(ResultsExporterActor.defaultProps(exports), "resultsExporter")
     val manager = actorSystem.actorOf(Props(classOf[ManagerActor], sc, resultsExporter, terminator), "manager")
     logger.info("Starting the scenario")
     manager ! RunScenario

--- a/src/main/scala/eu/semberal/dbstress/actor/ResultsExporterActor.scala
+++ b/src/main/scala/eu/semberal/dbstress/actor/ResultsExporterActor.scala
@@ -32,9 +32,8 @@ class ResultsExporterActor(resultsExport: Seq[ResultsExport]) extends Actor {
 
 object ResultsExporterActor {
 
-  def defaultProps(outputDir: File) = {
-    val defaultResultExporters = new JsonResultsExport(outputDir) :: new CsvResultsExport(outputDir) :: Nil
-    Props(classOf[ResultsExporterActor], defaultResultExporters)
+  def defaultProps(resultExports: List[ResultsExport]) = {
+    Props(classOf[ResultsExporterActor], resultExports)
   }
 
   case class ExportResults(scenarioResult: ScenarioResult)

--- a/src/test/scala/eu/semberal/dbstress/actor/ResultsExporterActorTest.scala
+++ b/src/test/scala/eu/semberal/dbstress/actor/ResultsExporterActorTest.scala
@@ -8,6 +8,7 @@ import akka.testkit.{ImplicitSender, TestKit}
 import akka.util.Timeout
 import eu.semberal.dbstress.actor.ResultsExporterActor.ExportResults
 import eu.semberal.dbstress.model.Results.ScenarioResult
+import eu.semberal.dbstress.util.{CsvResultsExport, JsonResultsExport, ResultsExport}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
 
@@ -23,7 +24,9 @@ class ResultsExporterActorTest
   override protected def afterAll(): Unit = TestKit.shutdownActorSystem(system)
 
   trait failedActorScope {
-    val actor = system.actorOf(ResultsExporterActor.defaultProps(new File("/root")))
+    val outputDir: File = new File("/root")
+    val exports: List[ResultsExport] = new JsonResultsExport(outputDir) :: new CsvResultsExport(outputDir) :: Nil
+    val actor = system.actorOf(ResultsExporterActor.defaultProps(exports))
   }
 
   "ResultsExporterActor" should "respond with exception when an error occurs" in new failedActorScope {


### PR DESCRIPTION
The motivation behind this PR is to make the `Orchestrator` more flexible by taking a list of exporters in constructor instead of creating it on its own.
