### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM hseeberger/scala-sbt
+
+ADD . /usr/src/dbstress/
+WORKDIR /usr/src/dbstress/
+
+RUN sbt packArchive
+
+ENTRYPOINT [ "./target/pack/bin/dbstress" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+dbstress:
+  build: .
+  links:
+    - mysql
+  volumes:
+    - ./src/tests/resources/:/scenarios/:ro
+
+mysql:
+  image: mariadb
+  environment:
+    - MYSQL_ROOT_PASSWORD=root
+    - MYSQL_USER=user
+    - MYSQL_PASSWORD=user


### PR DESCRIPTION
Add Dockerfile to enable image building. Useful for development and tests under Docker workflow.
Using the hseeberger/scala-sbt image, which looks like the most popular Scala/sbt image.

Just adding files, setting working dir and running build instructions.
Scenarios can be mounted from outside of the container (as done in the examples below).

Build:

```
$ docker build -t dbstress .
```

Run:

```
$ docker run --rm -it -v /your/host/scenarios/dir/:/scenarios/ dbstress [options...]
```

FYI, there's a still quicker to test, already built image on my Docker Hub. Test it by running:

```
$ docker run --rm -it -v /your/host/scenarios/dir/:/scenarios/ dbstress [options...]
```
Using `--rm` causes the container to be deleted after stop.

Included is a testing Docker Compose manifest file to launch a MariaDB server alongside the built image. Test scenarios are mounted. Run it by just doing:
```
docker-compose up --build
```

Optional improvement to come (maybe in another issue):
- Create an 'official', based on your repo, automated build at Docker Hub for the image: https://docs.docker.com/docker-hub/builds/ . Just requires a free Docker Hub account and a following a quick 'Create automated build' process. I'll be happy to help on it, if needed.