### PR TITLE
Dockerfile: fix base image no longer working

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hseeberger/scala-sbt
+FROM sbtscala/scala-sbt:eclipse-temurin-jammy-17.0.5_8_1.8.2_3.2.2
 
 ADD . /usr/src/dbstress/
 WORKDIR /usr/src/dbstress/


### PR DESCRIPTION
Dockerfile was no longer working, since base image no longer has a `:latest` tag (the default).
It also is deprecated in favor of https://hub.docker.com/r/sbtscala/scala-sbt/
However, it doesn't support the `:latest`tag, so you have to use specific version tags. See docs for more info.
I've picked the one using Jammy (latest Ubuntu LTS) and JDK8.